### PR TITLE
Add dependency dnsutils && update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,27 @@ zone "_le.example.org" {
 };
 ```
 
+Format for `/etc/letsencrypt/keys/ddns_update.key` (from bind)
+
+```
+key "<key>" {
+    algorithm HMAC-SHA512;
+    secret "<key>";
+};
+```
+
+Format for `/etc/letsencrypt/keys/ddns_update.private`
+
+```
+Private-key-format: v1.3
+Algorithm: 165 (HMAC_SHA512)
+Key: <key>
+Bits: AAA=
+Created: 20181017144534
+Publish: 20181017144534
+Activate: 20181017144534
+```
+
 # Ansible variable defaults
 
 ```

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,9 @@
 ---
+- name: install nsupdate which is used by the certbot auth-hook
+  apt:
+    pkg: dnsutils
+    state: present
+  when: letsencrypt_cert.challenge|default() == 'dns'
 
 - name: install Let's Encrypt Certbot client
   apt:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,7 +3,7 @@
   apt:
     pkg: dnsutils
     state: present
-  when: letsencrypt_cert.challenge|default() == 'dns'
+  when: letsencrypt_cert is defined and letsencrypt_cert.challenge|default() == 'dns'
 
 - name: install Let's Encrypt Certbot client
   apt:


### PR DESCRIPTION
Hey,
I fixed a missing dependeny and updated the docs.  

What's the reason for the switch (install vs get certificate)?
- include: install.yml
  when: not letsencrypt_cert|d()

- include: certificate.yml
  when: letsencrypt_cert|d()

Why can't we run both all the time? Should work imo.

Greetings 
kmille