### PR TITLE
allow to define install or certificate mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 
+# default action to execute: install or certificate
+letsencrypt_mode: certificate
+
 # Set the email address associated with the Let's Encrypt account
 letsencrypt_account_email: ""
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 
-- include: install.yml
-  when: not letsencrypt_cert|d()
+- name: Install when letsencrypt_cert is not defined
+  set_fact:
+    letsencrypt_mode: install
+  when: letsencrypt_cert is not defined
 
-- include: certificate.yml
-  when: letsencrypt_cert|d()
+- include_tasks: "{{ letsencrypt_mode }}.yml"


### PR DESCRIPTION
This is probably open for discussion, but one thing I found strange in the role is that you can't install when you already have the variables defined for your certificate. That makes it harder to preconfigure everything for a host's deployment. This PR is a possible solution for that, while it should be backwards compatible.

In my playbook I call the role twice, the first time installs and the second time generates the certificate.
    - role: ansible-role-letsencrypt
      letsencrypt_mode: install
    - role: ansible-role-letsencrypt
      letsencrypt_mode: certificate

Comments and ideas welcome.