### PR TITLE
Add nginx support

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -18,4 +18,11 @@
     pkg: python3-certbot-apache
     state: present
     cache_valid_time: 600
-  when: ansible_fqdn in groups[letsencrypt_webserver_groupname]|d([])
+  when: ansible_fqdn in groups[letsencrypt_webserver_groupname]|d([]) and letsencrypt_http_auth == 'apache'
+
+- name: install certbot plugin 'nginx' on webservers
+  apt:
+    pkg: python3-certbot-nginx
+    state: present
+    cache_valid_time: 600
+  when: ansible_fqdn in groups[letsencrypt_webserver_groupname]|d([]) and letsencrypt_http_auth == 'nginx'

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -5,6 +5,11 @@
     letsencrypt_opt_http_auth: "--apache"
   when: letsencrypt_cert.http_auth|default(letsencrypt_http_auth) == 'apache'
 
+- name: prepare authenticator options for nginx
+  set_fact:
+    letsencrypt_opt_http_auth: "--nginx"
+  when: letsencrypt_cert.http_auth|default(letsencrypt_http_auth) == 'nginx'
+
 - name: prepare authenticator options for standalone
   set_fact:
     letsencrypt_opt_http_auth: "--standalone"


### PR DESCRIPTION
Added nginx support for at least for Debian.

I was playing with `systemli/ansible-role-jitsi-meet`. Since I couldn't use `dns` but had to use `http`, it makes more sense for me to use `nginx` instead of `apache`.