### PR TITLE
Rework http constraint (fixes #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The dictionary supports the following keys:
 * `post_hook`: Custom post-hook to be executed after attempt to obtain/renew
   a certificate [optional]
 * `deploy_hook`: Custom deploy-hook to be executed after a successful attempt
-  to obtain/renew  a certificate [optional]  
+  to obtain/renew  a certificate [optional]
 * `renew_hook`: Custom renew-hook to be executed once for each renewed
   certificate after certificate renewal [optional]
 * `users`: list of users to be added to system group 'letsencrypt' [optional]
@@ -245,9 +245,6 @@ letsencrypt_http_auth: webroot
 
 # Default webroot path for the authenticator 'webroot'
 letsencrypt_webroot_path: /var/www
-
-# Default group name of the webservers in the inventory file
-letsencrypt_webserver_groupname: web
 
 # Install the DNS challenge helper script and DNS update key
 letsencrypt_dns_challenge: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,9 +12,6 @@ letsencrypt_http_auth: webroot
 # Default webroot path for the authenticator 'webroot'
 letsencrypt_webroot_path: /var/www
 
-# Default group name of the webservers in the inventory file
-letsencrypt_webserver_groupname: web
-
 # Install the DNS challenge helper script and DNS update key
 letsencrypt_dns_challenge: yes
 

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -18,11 +18,11 @@
     pkg: python3-certbot-apache
     state: present
     cache_valid_time: 600
-  when: ansible_fqdn in groups[letsencrypt_webserver_groupname]|d([]) and letsencrypt_http_auth == 'apache'
+  when: letsencrypt_cert is defined and letsencrypt_cert.challenge|default() == 'http' and letsencrypt_http_auth == 'apache'
 
 - name: install certbot plugin 'nginx' on webservers
   apt:
     pkg: python3-certbot-nginx
     state: present
     cache_valid_time: 600
-  when: ansible_fqdn in groups[letsencrypt_webserver_groupname]|d([]) and letsencrypt_http_auth == 'nginx'
+  when: letsencrypt_cert is defined and letsencrypt_cert.challenge|default() == 'http' and letsencrypt_http_auth == 'nginx'

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -20,10 +20,10 @@
   yum:
     name: python2-certbot-apache
     state: present
-  when: ansible_fqdn in groups[letsencrypt_webserver_groupname]|d([])
+  when: letsencrypt_cert is defined and letsencrypt_cert.challenge|default() == 'http' and letsencrypt_http_auth == 'apache'
 
 - name: install certbot plugin 'nginx' on webservers
   yum:
     name: python2-certbot-nginx
     state: present
-  when: ansible_fqdn in groups[letsencrypt_webserver_groupname]|d([])
+  when: letsencrypt_cert is defined and letsencrypt_cert.challenge|default() == 'http' and letsencrypt_http_auth == 'nginx'


### PR DESCRIPTION
Following the discussion in #51, I removed the reference to `letsencrypt_webserver_groupname` in the `http` conditions.
Instead, I check whether `letsencrypt_cert.challenge` is set to `http`.

Moreover, for both Debian and RedHat it is checked which webserver (`apache`/`nginx`) is selected, so that only one of the certbot plugins is installed.
It should be noted that the certbot plugin packages have the corresponding webserver set as a dependency - so it makes even more sense to install just one of them.

@doobry-systemli Could you review this PR, please?