### PR TITLE
Added letsencrypt_directory as variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,5 +33,5 @@ letsencrypt_subset_names: True
 # Set global extra commandline options for certbot
 letsencrypt_opts_extra: ""
 
-# Set path for letsencrypt directory
+# Set path for letsencrypt directory (no trailing "/" !!)
 letsencrypt_directory: /etc/letsencrypt

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,6 @@ letsencrypt_subset_names: True
 
 # Set global extra commandline options for certbot
 letsencrypt_opts_extra: ""
+
+# Set path for letsencrypt directory
+letsencrypt_directory: /etc/letsencrypt

--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -134,7 +134,7 @@
   block:
     - name: get dest of current private key
       file:
-        path: /etc/letsencrypt/live/{{ letsencrypt_cert.name }}/privkey.pem
+        path: "{{ letsencrypt_directory }}/live/{{ letsencrypt_cert.name }}/privkey.pem"
         state: link
       register: privkey
       check_mode: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,7 +11,7 @@
         owner: root
         group: root
         mode: 0755
-    - name: create directory {{ letsencrypt_directory }}/keys
+    - name: create letsencrypt directory
       file:
         dest: "{{ letsencrypt_directory }}/keys"
         state: directory

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,9 +11,9 @@
         owner: root
         group: root
         mode: 0755
-    - name: create directory /etc/letsencrypt/keys
+    - name: create directory {{ letsencrypt_directory }}/keys
       file:
-        dest: /etc/letsencrypt/keys
+        dest: "{{ letsencrypt_directory }}/keys"
         state: directory
         owner: root
         group: root
@@ -21,7 +21,7 @@
     - name: install certbot DNS challenge nsupdate key
       copy:
         content: "{{ letsencrypt_ddns_key }}"
-        dest: /etc/letsencrypt/keys/ddns_update.key
+        dest: "{{ letsencrypt_directory }}/keys/ddns_update.key"
         owner: root
         group: root
         mode: 0400
@@ -29,7 +29,7 @@
     - name: install certbot DNS challenge nsupdate private key
       copy:
         content: "{{ letsencrypt_ddns_privkey }}"
-        dest: /etc/letsencrypt/keys/ddns_update.private
+        dest: "{{ letsencrypt_directory }}/keys/ddns_update.private"
         owner: root
         group: root
         mode: 0400
@@ -50,8 +50,8 @@
         group: letsencrypt
         mode: 0750
       with_items:
-        - /etc/letsencrypt/archive
-        - /etc/letsencrypt/live
+        - "{{ letsencrypt_directory }}/archive"
+        - "{{ letsencrypt_directory }}/live"
   when: letsencrypt_group
 
 - name: check if letsencrypt_account_email is set
@@ -65,7 +65,7 @@
 
 - name: check if a Let's Encrypt account exists
   stat:
-    path: /etc/letsencrypt/accounts
+    path: "{{ letsencrypt_directory }}/accounts"
   register: letsencrypt_reg_accounts_dir
 
 - name: prepare optional test cert option

--- a/templates/certbot-dns-hook.sh.j2
+++ b/templates/certbot-dns-hook.sh.j2
@@ -22,7 +22,7 @@ fi
 CERTBOT_DOMAIN="${CERTBOT_DOMAIN#\*\.}"
 
 # Key for the dynamic DNS updates
-DDNS_KEY='/etc/letsencrypt/keys/ddns_update.key'
+DDNS_KEY='{{ letsencrypt_directory }}/keys/ddns_update.key'
 
 # Nameserver with the dynamic zone
 SERVER="{{ letsencrypt_ddns_server|d() }}"


### PR DESCRIPTION
I added a letsencrypt_directory variable in `defaults/main.yml` and updated `cartificate.yml` and `install.yml`.
The variable is set to /etc/letsencrypt by default.
#29